### PR TITLE
add `{fillInputAndData: true,}` to `eth_call` on method_wrappers

### DIFF
--- a/packages/web3-eth/src/rpc_method_wrappers.ts
+++ b/packages/web3-eth/src/rpc_method_wrappers.ts
@@ -951,7 +951,7 @@ export async function call<ReturnFormat extends DataFormat>(
 
 	const response = await ethRpcMethods.call(
 		web3Context.requestManager,
-		formatTransaction(transaction, ETH_DATA_FORMAT),
+		formatTransaction(transaction, ETH_DATA_FORMAT, {fillInputAndData: true,}),
 		blockNumberFormatted,
 	);
 


### PR DESCRIPTION
## Description

The `fillInputData` option on `formatTransaction` call that was introduced [with this change](https://github.com/web3/web3.js/pull/6294/files#diff-0c52e30746e2e9181931331752f8cb162bc84dba5e7a8cd093509681c8c2707fR64) left `eth_call` method unchanged. In my case, `4.1.0` was unable to call a simple `ERC20.name()` returning `unkown function selector` (even if the contract had a fallback).

Adding this argument to the function call when `call()` is made fixed it on my side.

- (should) Fix #6355

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

